### PR TITLE
chore: migrate vite-plugin-dts -> unplugin-dts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "build:app": "vite build --config vite-app.config.ts",
     "lint": "eslint src/lib",
     "format:check": "prettier --check src/lib",
+    "format:write": "prettier --write src/lib",
     "typecheck": "tsc",
-    "preview": "vite preview",
+    "preview:app": "vite preview",
     "local-release": "changeset version && changeset publish",
     "prepublishOnly": "pnpm run ci"
   },

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "tailwindcss": "^4.2.4",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.1",
-    "vite": "^8.0.10",
-    "vite-plugin-dts": "^5.0.0"
+    "unplugin-dts": "^1.0.0",
+    "vite": "^8.0.10"
   },
   "packageManager": "pnpm@10.4.1",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,12 +75,12 @@ importers:
       typescript-eslint:
         specifier: ^8.59.1
         version: 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      unplugin-dts:
+        specifier: ^1.0.0
+        version: 1.0.0(@microsoft/api-extractor@7.52.8(@types/node@24.12.2))(esbuild@0.27.2)(rollup@4.55.1)(typescript@5.9.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1))
       vite:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)
-      vite-plugin-dts:
-        specifier: ^5.0.0
-        version: 5.0.0(@microsoft/api-extractor@7.52.8(@types/node@24.12.2))(esbuild@0.27.2)(rollup@4.55.1)(typescript@5.9.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1))
 
 packages:
 
@@ -1951,20 +1951,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  vite-plugin-dts@5.0.0:
-    resolution: {integrity: sha512-VLNAUttBq7pLxxL/m/ztjd5zj5yiviiC7ijfPFVLK5c45FLcibvieBsdjSka3a4ag1qdrAF9K3OysH4/lW+rPQ==}
-    peerDependencies:
-      '@microsoft/api-extractor': '>=7'
-      rollup: '>=3'
-      vite: '>=3'
-    peerDependenciesMeta:
-      '@microsoft/api-extractor':
-        optional: true
-      rollup:
-        optional: true
-      vite:
-        optional: true
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -3841,22 +3827,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  vite-plugin-dts@5.0.0(@microsoft/api-extractor@7.52.8(@types/node@24.12.2))(esbuild@0.27.2)(rollup@4.55.1)(typescript@5.9.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)):
-    dependencies:
-      unplugin-dts: 1.0.0(@microsoft/api-extractor@7.52.8(@types/node@24.12.2))(esbuild@0.27.2)(rollup@4.55.1)(typescript@5.9.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1))
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.52.8(@types/node@24.12.2)
-      rollup: 4.55.1
-      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@vue/language-core'
-      - esbuild
-      - rolldown
-      - supports-color
-      - typescript
-      - webpack
 
   vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.6.1):
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,14 +4,18 @@ import { fileURLToPath } from 'node:url';
 import { glob } from 'glob';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
-import dts from 'vite-plugin-dts';
+import dts from 'unplugin-dts/vite';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     react(),
     tailwindcss(),
-    dts({ include: ['src/lib'], tsconfigPath: './tsconfig.build.json' }),
+    dts({
+      include: ['src/lib'],
+      tsconfigPath: './tsconfig.build.json',
+      outDirs: 'dist/types',
+    }),
   ],
   build: {
     lib: {


### PR DESCRIPTION
vite-plugin-dts@4.5.4 is the legacy package version, unplugin-dts@1.0.0 is a rewrite for the [unplugin](https://unplugin.unjs.io/) ecosystem which is now recommended, vite-plugin-dts@5.0.0 just re-exports from unplugin-dts for backwards compatibility

bundlephobia comparison:
- [vite-plugin-dts@4.5.4](https://bundlephobia.com/package/vite-plugin-dts@4.5.4)
- [vite-plugin-dts@5.0.0
](https://bundlephobia.com/package/vite-plugin-dts@5.0.0)
- [unplugin-dts@1.0.0](https://bundlephobia.com/package/unplugin-dts@1.0.0)